### PR TITLE
Respect OS color scheme preference

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[src/**/*]
+indent_style = space
+indent_size = 2

--- a/src/store.js
+++ b/src/store.js
@@ -3,6 +3,8 @@ import Vuex from 'vuex';
 import axios from 'axios';
 import createPersistedState from 'vuex-persistedstate';
 
+import prefersDarkMode from './utils/prefers-dark-mode';
+
 Vue.use(Vuex);
 
 const GITHUB = 'github';
@@ -13,7 +15,7 @@ export default new Vuex.Store({
   plugins: [createPersistedState()],
   state: {
     settings: {
-      isNightMode: false,
+      isNightMode: prefersDarkMode(),
       cards: [GITHUB, HACKERNEWS, PRODUCTHUNT],
     },
     github: {

--- a/src/utils/prefers-dark-mode.js
+++ b/src/utils/prefers-dark-mode.js
@@ -1,0 +1,10 @@
+export default function prefersDarkMode() {
+  const hasMatchMedia = 'matchMedia' in window;
+  if (!hasMatchMedia) {
+    return false;
+  }
+
+  const darkModeQuery = '(prefers-color-scheme: dark)';
+
+  return window.matchMedia(darkModeQuery).matches;
+}


### PR DESCRIPTION
This PR adds a check for the `prefers-color-scheme: dark` media query when creating the initial store.