### PR TITLE
feature/remove axios dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1958,32 +1958,6 @@
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
     },
-    "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "requires": {
-        "follow-redirects": "1.5.10"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        }
-      }
-    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -8248,7 +8222,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "multicast-dns": {
       "version": "6.2.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/vue-fontawesome": "^0.1.10",
-    "axios": "^0.19.2",
     "flexboxgrid": "^6.3.1",
     "vue": "^2.6.12",
     "vuex": "^3.5.1",

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import axios from 'axios';
 import createPersistedState from 'vuex-persistedstate';
 
 import prefersDarkMode from './utils/prefers-dark-mode';
@@ -78,10 +77,10 @@ export default new Vuex.Store({
       const now = new Date();
 
       if (!lastUpdate || now - lastUpdate > threshold || forced) {
-        const response = await axios.get(url);
-        let data = response.data;
+        const response = await fetch(url);
+        let data = await response.json();
         if ('responseDataKey' in platformConfig) {
-          data = response.data[platformConfig.responseDataKey];
+          data = data[platformConfig.responseDataKey];
         }
         commit('setPlatformData', { platform, data });
       }


### PR DESCRIPTION
This PR replaces the `axios` dependency with the Fetch API, essentially resulting in one less dependency with a reduction of ~6.8% on the bundle size, bringing the total size to 177.75KiB.

```
  File                          Size                   Gzipped

  dist/js/chunk-vendors.js      177.75 KiB             60.65 KiB
  dist/js/app.js                35.41 KiB              7.87 KiB
  dist/css/app.css              15.89 KiB              3.08 KiB
  dist/css/chunk-vendors.css    12.15 KiB              1.58 KiB
```