### PR TITLE
feature/layout select

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,11 +18,16 @@
               <a href="https://github.com/karakanb/devo">open-source extension</a>.
             </span>
 
-            <span class="pull-right day-night-toggle">
-              <font-awesome-icon :icon="['fas', 'sun']"></font-awesome-icon>
-              <toggle-switch v-model="nightModeToggle" style="margin-right: 8px"></toggle-switch>
-              <font-awesome-icon :icon="['fas', 'moon']" style="margin: 0"></font-awesome-icon>
-            </span>
+            <div class="pull-right day-night-toggle">
+              <div>
+                <layout-select></layout-select>
+              </div>
+              <div>
+                <font-awesome-icon :icon="['fas', 'sun']"></font-awesome-icon>
+                <toggle-switch v-model="nightModeToggle" style="margin-right: 8px"></toggle-switch>
+                <font-awesome-icon :icon="['fas', 'moon']" style="margin: 0"></font-awesome-icon>
+              </div>
+            </div>
           </footer>
         </div>
       </div>
@@ -34,7 +39,7 @@
 import { mapState, mapActions } from 'vuex';
 import Card from './components/Card.vue';
 import ToggleSwitch from './components/ToggleSwitch.vue';
-import PlatformCard from './components/PlatformCard.vue';
+import LayoutSelect from './components/LayoutSelect.vue';
 import SingleColumn from './layouts/SingleColumn.vue';
 import TwoColumns from './layouts/TwoColumns.vue';
 import ThreeColumns from './layouts/ThreeColumns.vue';
@@ -47,7 +52,7 @@ export default {
   components: {
     Card,
     ToggleSwitch,
-    PlatformCard,
+    LayoutSelect,
     SingleColumn,
     TwoColumns,
     ThreeColumns,
@@ -77,12 +82,8 @@ export default {
     },
     ...mapState({
       isNightMode: (state) => state.settings.isNightMode,
+      layout: (state) => state.settings.layout,
     }),
-
-    layout() {
-      return 'OneLeftTwoRight';
-    },
-
     nightModeToggle: {
       get() {
         return this.isNightMode;

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,11 +18,11 @@
               <a href="https://github.com/karakanb/devo">open-source extension</a>.
             </span>
 
-            <div class="pull-right day-night-toggle">
-              <div>
+            <div class="pull-right day-night-toggle flex items-center">
+              <div style="margin-right: 12px;">
                 <layout-select></layout-select>
               </div>
-              <div>
+              <div class="flex items-center">
                 <font-awesome-icon :icon="['fas', 'sun']"></font-awesome-icon>
                 <toggle-switch v-model="nightModeToggle" style="margin-right: 8px"></toggle-switch>
                 <font-awesome-icon :icon="['fas', 'moon']" style="margin: 0"></font-awesome-icon>
@@ -159,6 +159,14 @@ body {
 .day-night-toggle svg {
   margin-top: 0;
   margin-bottom: 0;
+}
+
+.flex {
+  display: flex;
+}
+
+.items-center {
+  align-items: center;
 }
 
 .pull-right {

--- a/src/components/LayoutSelect.vue
+++ b/src/components/LayoutSelect.vue
@@ -6,9 +6,8 @@
     v-outside="closeDropdown"
   >
     <div class="select-title-wrapper">
-      <span class="select-title"> {{ selectedLayoutDisplayName }}</span>
-      <span class="select-icon">
-        <font-awesome-icon icon="caret-up"></font-awesome-icon>
+      <span class="select-title">
+        <font-awesome-icon icon="th-large" style="margin: 0"></font-awesome-icon>
       </span>
     </div>
     <ul v-if="dropdownVisible" class="options round-borders with-shadow">
@@ -85,9 +84,9 @@ export default {
   width: 100%;
   display: inline-block;
   cursor: pointer;
-  min-width: 180px;
-  /* border: 1px solid grey; */
   box-sizing: border-box;
+  position: relative;
+  font-size: larger;
 }
 
 .options {
@@ -98,8 +97,9 @@ export default {
   position: absolute;
   background: white;
   color: black;
-  /* margin-top: 4px; */
-  bottom: 80px;
+  bottom: 28px;
+  right: 0;
+  border: 1px #535a635e solid;
 }
 
 .option-item {
@@ -124,6 +124,7 @@ export default {
 
 .select-title {
   padding: 5px;
+  line-height: 0;
   display: inline-block;
 }
 
@@ -166,6 +167,7 @@ export default {
 /* Here comes night-mode styling. */
 .night-mode .options {
   background-color: #25292f;
+  border: 1px #1e2123 solid;
   color: white;
 }
 

--- a/src/components/LayoutSelect.vue
+++ b/src/components/LayoutSelect.vue
@@ -1,0 +1,185 @@
+<template>
+  <div
+    class="round-borders wrapper"
+    :class="{ 'hovered-wrapper': this.dropdownVisible }"
+    @click="toggleDropdown"
+    v-outside="closeDropdown"
+  >
+    <div class="select-title-wrapper">
+      <span class="select-title"> {{ selectedLayoutDisplayName }}</span>
+      <span class="select-icon">
+        <font-awesome-icon icon="caret-up"></font-awesome-icon>
+      </span>
+    </div>
+    <ul v-if="dropdownVisible" class="options round-borders with-shadow">
+      <li
+        v-for="layout in this.layouts"
+        :key="layout.component"
+        @click="select(layout.component)"
+        class="option-item round-borders"
+        :class="{ selected: layout.component === selectedLayout }"
+      >
+        <span class="platform-title">{{ layout.displayName }}</span>
+        <span v-if="layout.component === selectedLayout" class="platform-selected-icon">
+          <font-awesome-icon icon="check"></font-awesome-icon>
+        </span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+import { mapState, mapActions } from 'vuex';
+import settings from '@/settings';
+
+export default {
+  data() {
+    return {
+      dropdownVisible: false,
+      layouts: settings.layouts,
+    };
+  },
+  methods: {
+    toggleDropdown() {
+      this.dropdownVisible = !this.dropdownVisible;
+    },
+    closeDropdown() {
+      this.dropdownVisible = false;
+    },
+    select(layout) {
+      this.dropdownVisible = false;
+      this.setLayout(layout);
+    },
+    ...mapActions(['setLayout']),
+  },
+  computed: {
+    ...mapState({
+      selectedLayout: (state) => state.settings.layout,
+    }),
+    selectedLayoutDisplayName() {
+      return this.layouts.find((layout) => layout.component === this.selectedLayout).displayName;
+    },
+  },
+  directives: {
+    outside: {
+      bind(el, binding, vnode) {
+        el.clickOutsideEvent = (event) => {
+          // check that click was outside the el and his childrens
+          if (!(el === event.target || el.contains(event.target))) {
+            // if it was, call method provided in attribute value
+            vnode.context[binding.expression](event);
+          }
+        };
+        document.body.addEventListener('click', el.clickOutsideEvent);
+      },
+      unbind(el) {
+        document.body.removeEventListener('click', el.clickOutsideEvent);
+      },
+    },
+  },
+};
+</script>
+
+<style scoped>
+.wrapper {
+  width: 100%;
+  display: inline-block;
+  cursor: pointer;
+  min-width: 180px;
+  /* border: 1px solid grey; */
+  box-sizing: border-box;
+}
+
+.options {
+  margin: 0;
+  padding: 0px;
+  list-style-type: none;
+  z-index: 9999;
+  position: absolute;
+  background: white;
+  color: black;
+  /* margin-top: 4px; */
+  bottom: 80px;
+}
+
+.option-item {
+  padding: 8px 12px 8px 12px;
+  cursor: pointer;
+  font-weight: 200;
+  display: flex;
+  align-items: center;
+  min-width: 200px;
+}
+
+.option-item.selected,
+.option-item:hover {
+  background: #f5f7fa;
+}
+
+.select-icon {
+  display: none;
+  color: #ffffff82;
+  margin-left: auto;
+}
+
+.select-title {
+  padding: 5px;
+  display: inline-block;
+}
+
+.hovered-wrapper,
+.wrapper:hover {
+  border: 1px solid rgb(255, 255, 255, 0.25);
+}
+
+.hovered-wrapper .select-title,
+.wrapper:hover .select-title {
+  padding: 4px;
+}
+
+.hovered-wrapper .select-icon,
+.wrapper:hover .select-icon {
+  display: inline-block;
+}
+
+.select-title-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.platform-color-box {
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  transition: box-shadow 0.1s;
+}
+.option-item:hover .platform-color-box {
+  box-shadow: 0 2px 8px 0 rgba(70, 73, 77, 0.16);
+}
+
+.platform-selected-icon {
+  color: #576068;
+  font-size: 12px;
+  margin-left: auto;
+}
+
+/* Here comes night-mode styling. */
+.night-mode .options {
+  background-color: #25292f;
+  color: white;
+}
+
+.night-mode .option-item.selected,
+.night-mode .option-item:hover {
+  background: #31363e;
+}
+
+.night-mode .platform-selected-icon {
+  color: #949494;
+}
+
+.night-mode .hovered-wrapper,
+.night-mode .wrapper:hover {
+  border: 1px solid rgba(130, 130, 130, 0.4);
+}
+</style>

--- a/src/components/LayoutSelect.vue
+++ b/src/components/LayoutSelect.vue
@@ -130,7 +130,7 @@ export default {
 
 .hovered-wrapper,
 .wrapper:hover {
-  border: 1px solid rgb(255, 255, 255, 0.25);
+  border: 1px solid #535a635e;
 }
 
 .hovered-wrapper .select-title,

--- a/src/layouts/OneLeftTwoRight.vue
+++ b/src/layouts/OneLeftTwoRight.vue
@@ -10,6 +10,7 @@
 import PlatformCard from '../components/PlatformCard.vue';
 
 export default {
+  name: 'OneLeftTwoRight',
   components: {
     PlatformCard,
   },

--- a/src/layouts/SingleColumn.vue
+++ b/src/layouts/SingleColumn.vue
@@ -8,9 +8,9 @@
 import PlatformCard from '../components/PlatformCard.vue';
 
 export default {
+  name: 'SingleColumn',
   components: {
     PlatformCard,
   },
-  methods: {},
 };
 </script>

--- a/src/layouts/ThreeColumns.vue
+++ b/src/layouts/ThreeColumns.vue
@@ -10,10 +10,10 @@
 import PlatformCard from '../components/PlatformCard.vue';
 
 export default {
+  name: 'ThreeColumns',
   components: {
     PlatformCard,
   },
-  methods: {},
 };
 </script>
 

--- a/src/layouts/TwoColumns.vue
+++ b/src/layouts/TwoColumns.vue
@@ -9,10 +9,10 @@
 import PlatformCard from '../components/PlatformCard.vue';
 
 export default {
+  name: 'TwoColumns',
   components: {
     PlatformCard,
   },
-  methods: {},
 };
 </script>
 

--- a/src/layouts/TwoLeftOneRight.vue
+++ b/src/layouts/TwoLeftOneRight.vue
@@ -10,6 +10,7 @@
 import PlatformCard from '../components/PlatformCard.vue';
 
 export default {
+  name: 'TwoLeftOneRight',
   components: {
     PlatformCard,
   },

--- a/src/layouts/TwoRowsTwoColumns.vue
+++ b/src/layouts/TwoRowsTwoColumns.vue
@@ -11,6 +11,7 @@
 import PlatformCard from '../components/PlatformCard.vue';
 
 export default {
+  name: 'TwoRowsTwoColumns',
   components: {
     PlatformCard,
   },

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import { library } from '@fortawesome/fontawesome-svg-core';
 import { faGithub, faHackerNewsSquare, faProductHunt, faDev } from '@fortawesome/free-brands-svg-icons';
 import {
   faSyncAlt, faCodeBranch, faStar, faChevronUp, faComment, faExternalLinkAlt, faSun, faMoon,
-  faCheck, faCaretUp, faCaretDown, faNewspaper, faHeart, faAnchor,
+  faCheck, faCaretUp, faCaretDown, faNewspaper, faHeart, faAnchor, faThLarge,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import App from './App.vue';
@@ -12,7 +12,7 @@ import store from './store';
 
 library.add([faGithub, faHackerNewsSquare, faProductHunt, faSyncAlt,
   faCodeBranch, faStar, faChevronUp, faComment, faExternalLinkAlt, faSun, faMoon, faCheck, faCaretUp, faCaretDown,
-  faNewspaper, faDev, faHeart, faAnchor]);
+  faNewspaper, faDev, faHeart, faAnchor, faThLarge]);
 Vue.component('font-awesome-icon', FontAwesomeIcon);
 
 Vue.config.productionTip = false;

--- a/src/main.js
+++ b/src/main.js
@@ -4,14 +4,14 @@ import { library } from '@fortawesome/fontawesome-svg-core';
 import { faGithub, faHackerNewsSquare, faProductHunt, faDev } from '@fortawesome/free-brands-svg-icons';
 import {
   faSyncAlt, faCodeBranch, faStar, faChevronUp, faComment, faExternalLinkAlt, faSun, faMoon,
-  faCheck, faCaretDown, faNewspaper, faHeart, faAnchor,
+  faCheck, faCaretUp, faCaretDown, faNewspaper, faHeart, faAnchor,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import App from './App.vue';
 import store from './store';
 
 library.add([faGithub, faHackerNewsSquare, faProductHunt, faSyncAlt,
-  faCodeBranch, faStar, faChevronUp, faComment, faExternalLinkAlt, faSun, faMoon, faCheck, faCaretDown,
+  faCodeBranch, faStar, faChevronUp, faComment, faExternalLinkAlt, faSun, faMoon, faCheck, faCaretUp, faCaretDown,
   faNewspaper, faDev, faHeart, faAnchor]);
 Vue.component('font-awesome-icon', FontAwesomeIcon);
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,3 +1,10 @@
+import SingleColumn from './layouts/SingleColumn.vue';
+import TwoColumns from './layouts/TwoColumns.vue';
+import ThreeColumns from './layouts/ThreeColumns.vue';
+import TwoLeftOneRight from './layouts/TwoLeftOneRight.vue';
+import OneLeftTwoRight from './layouts/OneLeftTwoRight.vue';
+import TwoRowsTwoColumns from './layouts/TwoRowsTwoColumns.vue';
+
 const DEFAULT_NIGHTMODE_BACKGROUND = '31363e';
 
 export default {
@@ -109,4 +116,30 @@ export default {
       },
     },
   },
+  layouts: [
+    {
+      displayName: 'Single Column',
+      component: SingleColumn.name,
+    },
+    {
+      displayName: 'Two Columns',
+      component: TwoColumns.name,
+    },
+    {
+      displayName: 'Three Columns',
+      component: ThreeColumns.name,
+    },
+    {
+      displayName: 'Two Left, One Right',
+      component: TwoLeftOneRight.name,
+    },
+    {
+      displayName: 'One Left, Two Right',
+      component: OneLeftTwoRight.name,
+    },
+    {
+      displayName: 'Four Cards',
+      component: TwoRowsTwoColumns.name,
+    },
+  ],
 };

--- a/src/store.js
+++ b/src/store.js
@@ -61,6 +61,7 @@ export default new Vuex.Store({
     settings: {
       isNightMode: getIsNightMode(),
       cards: [GITHUB, HACKERNEWS, PRODUCTHUNT, DESIGNERNEWS],
+      layout: 'OneLeftTwoRight',
     },
     github: {
       updated_at: 0,
@@ -102,6 +103,9 @@ export default new Vuex.Store({
     setCardPlatform(state, { index, platform }) {
       Vue.set(state.settings.cards, index, platform);
     },
+    setLayout(state, layout) {
+      state.settings.layout = layout;
+    },
     setPlatformData(state, { platform, data }) {
       state[platform].data = data;
       state[platform].updated_at = Date.now();
@@ -114,6 +118,10 @@ export default new Vuex.Store({
 
     setCardPlatform(context, payload) {
       context.commit('setCardPlatform', payload);
+    },
+
+    setLayout(context, layout) {
+      context.commit('setLayout', layout);
     },
 
     async updatePlatformData({ state, commit }, { platform, forced, url }) {


### PR DESCRIPTION
This PR is a follow-up for #51, which already introduced the functionality regarding storing and displaying different layouts. This PR is the user-facing part of that change: it introduces a simple dropdown (or should I say drop-up? is that even a word?) menu for selecting a layout.

The light mode looks like this:
<img width="445" alt="image" src="https://user-images.githubusercontent.com/16530606/98408446-74543100-2071-11eb-81fd-52d0423e5fa4.png">

The dark mode is also very similar:
<img width="443" alt="image" src="https://user-images.githubusercontent.com/16530606/98408250-24756a00-2071-11eb-8fb1-9a62b9476f2d.png">

For now, it doesn't include any layout icons since FontAwesome doesn't have any and I couldn't find an easy way of creating SVG versions myself, although I am open to contributions.
