### PR TITLE
Safari installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ __Devo__ is a Google Chrome and Mozilla Firefox extension that displays GitHub T
 ## Installation
 Devo can be installed for [Chrome here](https://chrome.google.com/webstore/detail/devo/elkhalpmbmbaeoemecpcfdcoekmpgmdm), and [Firefox here](https://addons.mozilla.org/en-US/firefox/addon/devo-new-tab/).
 
+For installation on Safari:
+1. [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify/netlify-statuskit)
+2. Once deployed, [update homepage on safari](https://support.apple.com/guide/safari/change-your-homepage-ibrw1020/mac).
+
 ## Demo
 [Demo can be found here.](https://burakkarakan.com/devo/)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ __Devo__ is a Google Chrome and Mozilla Firefox extension that displays GitHub T
 Devo can be installed for [Chrome here](https://chrome.google.com/webstore/detail/devo/elkhalpmbmbaeoemecpcfdcoekmpgmdm), and [Firefox here](https://addons.mozilla.org/en-US/firefox/addon/devo-new-tab/).
 
 For installation on Safari:
-1. [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify/netlify-statuskit)
+1. [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/karakanb/devo)
 2. Once deployed, [update homepage on safari](https://support.apple.com/guide/safari/change-your-homepage-ibrw1020/mac).
 
 ## Demo

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "dist"


### PR DESCRIPTION
# Description

People using safari can also use this as a homepage if they deploy this page to their own page and then use that link as a homepage link in safari.

## Changes

- Added instructions for installation of Devo on safari.
- Integrate deploy to Netlify.
