### PR TITLE
Support toggling dark mode automatically.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -74,11 +74,9 @@ export default {
     };
   },
   created() {
+    this.setNightMode(this.checkIsNightMode());
     setInterval(() => {
       this.nowTime = new Date();
-      if (!this.disableNightAutoToggle) {
-        this.setNightMode(this.checkIsNightMode());
-      }
     }, 1000);
   },
   computed: {
@@ -100,7 +98,6 @@ export default {
         return this.isNightMode;
       },
       set(value) {
-        this.disableNightAutoToggle = true;
         this.setNightMode(value);
       },
     },

--- a/src/App.vue
+++ b/src/App.vue
@@ -70,11 +70,15 @@ export default {
   data() {
     return {
       nowTime: new Date(),
+      disableNightAutoToggle: false,
     };
   },
   created() {
     setInterval(() => {
       this.nowTime = new Date();
+      if (!this.disableNightAutoToggle) {
+        this.setNightMode(this.checkIsNightMode());
+      }
     }, 1000);
   },
   computed: {
@@ -96,6 +100,7 @@ export default {
         return this.isNightMode;
       },
       set(value) {
+        this.disableNightAutoToggle = true;
         this.setNightMode(value);
       },
     },
@@ -130,6 +135,10 @@ export default {
       const day = date.getDate();
       const monthIndex = date.getMonth();
       return `${days[date.getDay()]}, ${monthNames[monthIndex]} ${day}`;
+    },
+    checkIsNightMode() {
+      const { matches } = window.matchMedia('(prefers-color-scheme: dark)');
+      return matches;
     },
 
     ...mapActions(['setNightMode']),

--- a/src/App.vue
+++ b/src/App.vue
@@ -70,7 +70,6 @@ export default {
   data() {
     return {
       nowTime: new Date(),
-      disableNightAutoToggle: false,
     };
   },
   created() {

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -94,6 +94,16 @@ export default {
   overflow-x: auto;
 }
 
+.night-mode .card-body::-webkit-scrollbar {
+  width: 5px;
+  background: rgb(49, 54, 62);
+}
+
+.night-mode .card-body::-webkit-scrollbar-thumb {
+  border-radius: 3px;
+  background-color: #dfe3e82d;
+}
+
 .card-title-text {
   font-weight: 600;
 }

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -85,23 +85,14 @@ export default {
   padding: 0 16px;
   overflow-x: auto;
   height: 100%;
+  scrollbar-color: #4f4f4f2e transparent;
+  scrollbar-width: thin;
 }
 
 .night-mode .card-body {
   background-color: #31363e;
   color: #c5c8ca;
-  padding: 0 16px;
-  overflow-x: auto;
-}
-
-.night-mode .card-body::-webkit-scrollbar {
-  width: 5px;
-  background: rgb(49, 54, 62);
-}
-
-.night-mode .card-body::-webkit-scrollbar-thumb {
-  border-radius: 3px;
-  background-color: #dfe3e82d;
+  scrollbar-color: #dfe3e82d transparent;
 }
 
 .card-title-text {

--- a/src/components/DesignerNews/Row.vue
+++ b/src/components/DesignerNews/Row.vue
@@ -92,6 +92,10 @@ export default {
   border-bottom: 1px solid #dfe3e8a8;
 }
 
+.night-mode .dn-item {
+  border-bottom: 1px solid #dfe3e82d;
+}
+
 .dn-item .row {
   margin: 0;
 }

--- a/src/components/Devto/Row.vue
+++ b/src/components/Devto/Row.vue
@@ -105,6 +105,11 @@ export default {
   color: #292929 !important;
 }
 
+.night-mode .devto-item {
+  border-bottom: 1px solid #dfe3e82d;
+}
+
+
 .night-mode .devto-item,
 .night-mode .devto-item .title {
   color: inherit !important;

--- a/src/components/GitHub/Row.vue
+++ b/src/components/GitHub/Row.vue
@@ -72,6 +72,10 @@ export default {
   border-bottom: 1px solid #dfe3e8a8;
 }
 
+.night-mode .gh-item {
+  border-bottom: 1px solid #dfe3e82d;
+}
+
 .gh-item {
   margin: 0;
 }

--- a/src/components/HackerNews/Row.vue
+++ b/src/components/HackerNews/Row.vue
@@ -59,6 +59,10 @@ export default {
   margin: 0;
 }
 
+.night-mode .hn-item {
+  border-bottom: 1px solid #dfe3e82d;
+}
+
 .hn-item a {
   text-decoration: none;
   color: inherit;

--- a/src/components/Lobsters/Row.vue
+++ b/src/components/Lobsters/Row.vue
@@ -98,6 +98,10 @@ export default {
   border-bottom: 1px solid #dfe3e8a8;
 }
 
+.night-mode .lr-item {
+  border-bottom: 1px solid #dfe3e82d;
+}
+
 .lr-item{
   margin: 0;
 }

--- a/src/components/ProductHunt/Row.vue
+++ b/src/components/ProductHunt/Row.vue
@@ -99,6 +99,10 @@ export default {
   border-bottom: 1px solid #dfe3e8a8;
 }
 
+.night-mode .ph-item {
+  border-bottom: 1px solid #dfe3e82d;
+}
+
 .ph-item a {
   text-decoration: none;
   color: inherit;


### PR DESCRIPTION
Hi, I found Devo is still in bright mode when My Browser have been in dark mode. So I make some changes to the code:

1. Checking dark mode automatically which is with `this.nowTime` under the same `setInterval`.
2. Adding a `disableNightAutoToggle` flag. When users trigger light/dark mode manually, the flag is turned `true` and the automatically dark mode checking will be blocked.
3. Modifying the style of card body scrollbar and list items' border color to make the look more comfortable in dark mode.